### PR TITLE
Remove codepen shortcode and update template

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [[headers]]
   for = "/*"
   [headers.values]
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' *.codepen.io *.withcabin.com *.netlify.app; connect-src 'self' *.withcabin.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: *.codepen.io *.netlify.app images.unsplash.com; object-src 'none'; frame-src codepen.io *.codepen.io *.netlify.app app.netlify.com; base-uri 'none'; manifest-src 'self' data:"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' *.codepen.io *.withcabin.com *.netlify.app; connect-src 'self' *.withcabin.com; style-src 'self' 'unsafe-inline'; img-src 'self' *.codepen.io data: *.codepen.io *.netlify.app images.unsplash.com; object-src 'none'; frame-src codepen.io *.codepen.io *.netlify.app app.netlify.com; base-uri 'none'; manifest-src 'self' data:"
 [build]
   command = "npm run build"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [[headers]]
   for = "/*"
   [headers.values]
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' *.codepen.io *.withcabin.com *.netlify.app; connect-src 'self' *.withcabin.com; style-src 'self' 'unsafe-inline'; img-src 'self' *.codepen.io; data: *.codepen.io *.netlify.app images.unsplash.com; object-src 'none'; frame-src codepen.io *.codepen.io *.netlify.app app.netlify.com; base-uri 'none'; manifest-src 'self' data:"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' *.codepen.io *.withcabin.com *.netlify.app; connect-src 'self' *.withcabin.com; style-src 'self' 'unsafe-inline'; img-src 'self' *.codepen.io *.netlify.app images.unsplash.com; object-src 'none'; frame-src codepen.io *.codepen.io *.netlify.app app.netlify.com; base-uri 'none'; manifest-src 'self' data:"
 [build]
   command = "npm run build"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [[headers]]
   for = "/*"
   [headers.values]
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' *.codepen.io *.withcabin.com *.netlify.app; connect-src 'self' *.withcabin.com; style-src 'self' 'unsafe-inline'; img-src 'self' *.codepen.io data: *.codepen.io *.netlify.app images.unsplash.com; object-src 'none'; frame-src codepen.io *.codepen.io *.netlify.app app.netlify.com; base-uri 'none'; manifest-src 'self' data:"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' *.codepen.io *.withcabin.com *.netlify.app; connect-src 'self' *.withcabin.com; style-src 'self' 'unsafe-inline'; img-src 'self' *.codepen.io; data: *.codepen.io *.netlify.app images.unsplash.com; object-src 'none'; frame-src codepen.io *.codepen.io *.netlify.app app.netlify.com; base-uri 'none'; manifest-src 'self' data:"
 [build]
   command = "npm run build"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [[headers]]
   for = "/*"
   [headers.values]
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' *.codepen.io *.withcabin.com *.netlify.app; connect-src 'self' *.withcabin.com; style-src 'self' 'unsafe-inline'; img-src 'self' *.codepen.io *.netlify.app images.unsplash.com; object-src 'none'; frame-src codepen.io *.codepen.io *.netlify.app app.netlify.com; base-uri 'none'; manifest-src 'self' data:"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' *.codepen.io *.withcabin.com *.netlify.app; connect-src 'self' *.withcabin.com; style-src 'self' 'unsafe-inline'; img-src 'self' *.codepen.io *.netlify.app images.unsplash.com data:; object-src 'none'; frame-src codepen.io *.codepen.io *.netlify.app app.netlify.com; base-uri 'none'; manifest-src 'self' data:"
 [build]
   command = "npm run build"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [[headers]]
   for = "/*"
   [headers.values]
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' *.codepen.io *.withcabin.com *.netlify.app; connect-src 'self' *.withcabin.com; style-src 'self' 'unsafe-inline'; img-src 'self' *.codepen.io *.netlify.app images.unsplash.com data:; object-src 'none'; frame-src codepen.io *.codepen.io *.netlify.app app.netlify.com; base-uri 'none'; manifest-src 'self' data:"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' *.codepen.io *.withcabin.com *.netlify.app; connect-src 'self' *.withcabin.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; object-src 'none'; frame-src codepen.io *.codepen.io *.netlify.app app.netlify.com; base-uri 'none'; manifest-src 'self' data:"
 [build]
   command = "npm run build"

--- a/src/_includes/projects.njk
+++ b/src/_includes/projects.njk
@@ -9,7 +9,7 @@
             {% image src,
             "" %}
           {% else %}
-            <img src="https://codepen.io/hexagoncircle/pen/{{ project.id }}/image/small.png" alt="" loading="lazy" data-is-loading/>
+            <img src="https://codepen.io/hexagoncircle/pen/{{ project.id }}/image/small.png" alt="" loading="lazy" data-is-loading="data-is-loading"/>
           {% endif %}
         </a>
       </li>
@@ -18,54 +18,12 @@
     <template id="projects-focus-text-template">
       <p id="projects-focus-text">
         <span>Navigate with left and right arrow keys</span>
-        <svg
-          class="icon focus-arrows"
-          aria-hidden="true"
-          xmlns="http://www.w3.org/2000/svg"
-          width="24"
-          height="24"
-          fill="currentcolor"
-          viewBox="0 0 256 256"
-        >
+        <svg class="icon focus-arrows" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentcolor" viewbox="0 0 256 256">
           <rect width="256" height="256" fill="none"></rect>
-          <polyline
-            points="160 48 208 48 208 96"
-            fill="none"
-            stroke="currentcolor"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="16"
-          ></polyline>
-          <line
-            x1="152"
-            y1="104"
-            x2="208"
-            y2="48"
-            fill="none"
-            stroke="currentcolor"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="16"
-          ></line>
-          <polyline
-            points="96 208 48 208 48 160"
-            fill="none"
-            stroke="currentcolor"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="16"
-          ></polyline>
-          <line
-            x1="104"
-            y1="152"
-            x2="48"
-            y2="208"
-            fill="none"
-            stroke="currentcolor"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="16"
-          ></line>
+          <polyline points="160 48 208 48 208 96" fill="none" stroke="currentcolor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"></polyline>
+          <line x1="152" y1="104" x2="208" y2="48" fill="none" stroke="currentcolor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"></line>
+          <polyline points="96 208 48 208 48 160" fill="none" stroke="currentcolor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"></polyline>
+          <line x1="104" y1="152" x2="48" y2="208" fill="none" stroke="currentcolor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"></line>
         </svg>
       </p>
     </template>

--- a/utils/shortcodes.js
+++ b/utils/shortcodes.js
@@ -22,34 +22,6 @@ module.exports = {
     <script async src="https://cpwebassets.codepen.io/assets/embed/ei.js"></script>`;
   },
 
-  codepenImage: async function (id) {
-    const url = `https://shots.codepen.io/hexagoncircle/pen/${id}-1280.jpg`;
-
-    let metadata = await Image(url, {
-      widths: [800],
-      ...sharedImageMetadata,
-      cacheOptions: {
-        duration: "2w",
-        directory: ".cache",
-        removeUrlQueryParams: false,
-      },
-      filenameFormat: function (id, src, width, format, options) {
-        const extension = path.extname(src);
-        const name = path.basename(src, extension).split("-")[0];
-        return `codepen-${name}.${format}`;
-      },
-    });
-
-    let imageAttributes = {
-      alt: "",
-      loading: "lazy",
-      decoding: "async",
-      "data-is-loading": true,
-    };
-
-    return Image.generateHTML(metadata, imageAttributes);
-  },
-
   image: async function (
     src,
     alt,


### PR DESCRIPTION
With the current `403 forbidden` error cropping up for project images, this switches over to using image tags with the sources pointing to the CodePen screenshot. The first few visible screenshots are still stored and optimized locally.